### PR TITLE
fix: parse power value for new Firmware Version (v2.0.0+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Simply put this in the accessories array of your config.json:
             "name": "NAME OF YOUR DEVICE",
             "ipAddress": "IP ADDRESS",
             "threshold": POWER_LEVEL_THRESHOLD,
-            "interval": INTERVAL_IN_MS
+            "interval": INTERVAL_IN_MS,
+			"minimumTime": MINIMUM_TIME_BETWEEN_STATE_CHANGES_IN_SECONDS
     }
 and adjust the values accordingly.

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,8 +84,8 @@ class LaundrifySensor {
 		// we are "soft updating" (without persisting) the state and start the timer
 		if ( this.lastPullState != currentState ) {
 			this.lastPullState = currentState
-				this.lastStateChange = new Date().getTime()
-			}
+			this.lastStateChange = new Date().getTime()
+		}
 
 		let secSinceChange = parseInt( (new Date().getTime() - this.lastStateChange) / 1000)
 		let persistedState = this.sensorService.getCharacteristic(Characteristic.ContactSensorState).value

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,13 +48,13 @@ class LaundrifySensor {
 
         var that = this;
         this.timer = setInterval(function () {
-            that.pollStatus(undefined, that)
+            that.pollStatus(that)
         }, this.interval)
     }
 
 
 
-    pollStatus(callback, that) {
+    pollStatus(that) {
         const status_url = 'http://' + that.ipAddress + '/status';
         const req = http.get(status_url, res => {
             let data = '';
@@ -64,9 +64,7 @@ class LaundrifySensor {
             res.on('end', () => {
                 var statusObject = JSON.parse(data);
                 that.power = statusObject.power;
-                if (callback != undefined) {
-                    callback();
-                }
+                this.update(statusObject)
             });
         }).on("error", (err) => {
             console.log('Could not connect to ' + this.name);
@@ -74,7 +72,10 @@ class LaundrifySensor {
     }
 
 
-
+update(statusObject) {
+	var isOn = (statusObject.power >= this.threshold);
+	this.sensorService.getCharacteristic(ContactSensorState).updateValue(isOn)
+}
 
 
     getSensorState(callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,36 +62,41 @@ class LaundrifySensor {
 				data += chunk;
 			});
 			res.on('end', () => {
-				var statusObject = JSON.parse(data);
-				that.power = statusObject.power;
-				this.update(statusObject)
+				let statusObject = JSON.parse(data)
+
+				// starting from v2.0.0 the Firmware Version is defined in `firmware.version` (previously `config.version`)
+				let firmwareVersion = statusObject.firmware ? statusObject.firmware.version : statusObject.config.version
+
+				// this.log.debug(`${this.name} is running on ${firmwareVersion}`)
+				that.power = firmwareVersion >= '2.0.0' ? statusObject.power.watts : statusObject.power
+
+				this.updateState()
 			});
 		}).on("error", (err) => {
 			console.log('Could not connect to ' + this.name);
 		});
 	}
 
-
-	update(statusObject) {
-		var time = new Date().getTime()
-		this.log.debug("Last state change was at " + this.lastStateChange)
-		this.log.debug("now is " + time)
-		this.log.debug("time difference is " + (time-this.lastStateChange))
-		this.log.debug("minimum time is " + (this.minimumTime * 1000))
+	updateState() {
+		let currentState = (this.power > this.threshold)
 			
-		var isOn = (statusObject.power >= this.threshold)
-		if ((time - this.lastStateChange) >= (this.minimumTime * 1000)) { 
-			this.log.debug("minimum time exceeded")
-
-			if (this.lastPullState != isOn) {
-				// got state change
-				this.log.debug(this.name + " state has changed")
-				this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(isOn)	
+		// if the current state is different than the one that has been pulled before
+		// we are "soft updating" (without persisting) the state and start the timer
+		if ( this.lastPullState != currentState ) {
+			this.lastPullState = currentState
 				this.lastStateChange = new Date().getTime()
 			}
-		}
 
-		this.lastPullState = isOn
+		let secSinceChange = parseInt( (new Date().getTime() - this.lastStateChange) / 1000)
+		let persistedState = this.sensorService.getCharacteristic(Characteristic.ContactSensorState).value
+
+		this.log.debug(`Pulled state: ${this.power}W (${currentState ? 'ON' : 'OFF'} since ${secSinceChange}s) | Persisted state: ${persistedState ? 'ON' : 'OFF'} | Thresholds: ${this.minimumTime}s / ${this.threshold}W`)
+		
+		// if the state is still different after <minimumTime> seconds we are going to persist the state
+		if (persistedState != currentState && secSinceChange >= this.minimumTime) {
+			this.log.debug(`State change exceeded time threshold! Persisting new state: ${currentState ? 'ON' : 'OFF'}`)
+			this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(currentState)
+		}
 	}
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,8 +18,11 @@ class LaundrifySensor {
 		this.ipAddress = config['ipAddress'];
 		this.threshold = parseInt(config['threshold']);
 		this.interval = parseInt(config['interval']);
+		this.minimumTime = parseInt(config['minimumTime'])
 		this.enabledServices = [];
 		this.timer = null;
+		this.lastStateChange = new Date().getTime()
+		this.lastPullState = false;
 		this.initSensor();
 	}
 
@@ -70,8 +73,17 @@ class LaundrifySensor {
 
 
 update(statusObject) {
-	var isOn = (statusObject.power >= this.threshold);
-	this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(isOn)
+	var time = new Date().getTime()
+	if ((time - this.lastStateChange) >= (this.minimumTime * 1000)) {   
+		var isOn = (statusObject.power >= this.threshold);
+		if (this.lastPullState != isOn) {
+			// got state change
+			
+			this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(isOn)	
+			this.lastStateChange = new Date().getTime()
+		}
+		this.lastPullState = isOn;	
+	}
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,16 +74,23 @@ class LaundrifySensor {
 
 update(statusObject) {
 	var time = new Date().getTime()
-	if ((time - this.lastStateChange) >= (this.minimumTime * 1000)) {   
+	this.log.debug("Last state change was at " + this.lastStateChange)
+	this.log.debug("now is " + time)
+	this.log.debug("time difference is " + (time-this.lastStateChange))
+	this.log.debug("minimum time is " + (this.minimumTime * 1000))
+		
 		var isOn = (statusObject.power >= this.threshold);
+		if ((time - this.lastStateChange) >= (this.minimumTime * 1000)) {   
+			this.log.debug("minimum time exceeded")
 		if (this.lastPullState != isOn) {
 			// got state change
-			
+			this.log.debug(this.name + " state has changed")
 			this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(isOn)	
 			this.lastStateChange = new Date().getTime()
 		}
-		this.lastPullState = isOn;	
 	}
+
+		this.lastPullState = isOn;	
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ class LaundrifySensor {
 
 update(statusObject) {
 	var isOn = (statusObject.power >= this.threshold);
-	this.sensorService.getCharacteristic(ContactSensorState).updateValue(isOn)
+	this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(isOn)
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,26 +72,27 @@ class LaundrifySensor {
 	}
 
 
-update(statusObject) {
-	var time = new Date().getTime()
-	this.log.debug("Last state change was at " + this.lastStateChange)
-	this.log.debug("now is " + time)
-	this.log.debug("time difference is " + (time-this.lastStateChange))
-	this.log.debug("minimum time is " + (this.minimumTime * 1000))
-		
-		var isOn = (statusObject.power >= this.threshold);
-		if ((time - this.lastStateChange) >= (this.minimumTime * 1000)) {   
+	update(statusObject) {
+		var time = new Date().getTime()
+		this.log.debug("Last state change was at " + this.lastStateChange)
+		this.log.debug("now is " + time)
+		this.log.debug("time difference is " + (time-this.lastStateChange))
+		this.log.debug("minimum time is " + (this.minimumTime * 1000))
+			
+		var isOn = (statusObject.power >= this.threshold)
+		if ((time - this.lastStateChange) >= (this.minimumTime * 1000)) { 
 			this.log.debug("minimum time exceeded")
-		if (this.lastPullState != isOn) {
-			// got state change
-			this.log.debug(this.name + " state has changed")
-			this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(isOn)	
-			this.lastStateChange = new Date().getTime()
-		}
-	}
 
-		this.lastPullState = isOn;	
-}
+			if (this.lastPullState != isOn) {
+				// got state change
+				this.log.debug(this.name + " state has changed")
+				this.sensorService.getCharacteristic(Characteristic.ContactSensorState).updateValue(isOn)	
+				this.lastStateChange = new Date().getTime()
+			}
+		}
+
+		this.lastPullState = isOn
+	}
 
 
 	getSensorState(callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,73 +3,70 @@ const http = require('http');
 let Service;
 let Characteristic;
 module.exports = function(homebridge) {
-    Service = homebridge.hap.Service;
-    Characteristic = homebridge.hap.Characteristic;
-    homebridge.registerAccessory('homebridge-laundrify', 'laundrify', LaundrifySensor);
+	Service = homebridge.hap.Service;
+	Characteristic = homebridge.hap.Characteristic;
+	homebridge.registerAccessory('homebridge-laundrify', 'laundrify', LaundrifySensor);
 };
 
 // --== MAIN CLASS ==--
 class LaundrifySensor {
-    constructor(log, config) {
-        this.log = log;
+	constructor(log, config) {
+		this.log = log;
 
-        // configuration
-        this.name = config['name'];
-        this.ipAddress = config['ipAddress'];
-        this.threshold = parseInt(config['threshold']);
-        this.interval = parseInt(config['interval']);
-        this.enabledServices = [];
-        this.timer = null;
-
-        this.initSensor();
-    }
-
-
-    // --== SETUP SERVICES  ==--
-    initSensor() {
-        // info service
+		// configuration
+		this.name = config['name'];
+		this.ipAddress = config['ipAddress'];
+		this.threshold = parseInt(config['threshold']);
+		this.interval = parseInt(config['interval']);
+		this.enabledServices = [];
+		this.timer = null;
+		this.initSensor();
+	}
 
 
-            this.informationService = new Service.AccessoryInformation();
-            this.informationService
-            .setCharacteristic(Characteristic.Manufacturer, 'laundrify')
-            .setCharacteristic(Characteristic.Model, 'laundrify')
-            .setCharacteristic(Characteristic.SerialNumber, 'serial')
-            .setCharacteristic(Characteristic.FirmwareRevision, 'FIRMWARE');
+	// --== SETUP SERVICES	==--
+	initSensor() {
+		// info service
 
-            this.enabledServices.push(this.informationService);
-            //this.log('Got information service');
-        // fan service
-        this.sensorService = new Service.ContactSensor(this.name);
-        this.sensorService
-        .getCharacteristic(Characteristic.ContactSensorState)
-        .on('get', this.getSensorState.bind(this));
-        this.enabledServices.push(this.sensorService);
-
-        var that = this;
-        this.timer = setInterval(function () {
-            that.pollStatus(that)
-        }, this.interval)
-    }
+		this.informationService = new Service.AccessoryInformation();
+		this.informationService
+			.setCharacteristic(Characteristic.Manufacturer, 'laundrify')
+			.setCharacteristic(Characteristic.Model, 'laundrify')
+			.setCharacteristic(Characteristic.SerialNumber, 'serial')
+			.setCharacteristic(Characteristic.FirmwareRevision, 'FIRMWARE');
+		this.enabledServices.push(this.informationService);
+		// this.log('Got information service');
+		// fan service
+		this.sensorService = new Service.ContactSensor(this.name);
+		this.sensorService
+			.getCharacteristic(Characteristic.ContactSensorState)
+			.on('get', this.getSensorState.bind(this));
+		this.enabledServices.push(this.sensorService);
+		
+		var that = this;
+		this.timer = setInterval(function () {
+			that.pollStatus(that)
+		}, this.interval)
+	}
 
 
 
-    pollStatus(that) {
-        const status_url = 'http://' + that.ipAddress + '/status';
-        const req = http.get(status_url, res => {
-            let data = '';
-            res.on('data', (chunk) => {
-                data += chunk;
-            });
-            res.on('end', () => {
-                var statusObject = JSON.parse(data);
-                that.power = statusObject.power;
-                this.update(statusObject)
-            });
-        }).on("error", (err) => {
-            console.log('Could not connect to ' + this.name);
-        });
-    }
+	pollStatus(that) {
+		const status_url = 'http://' + that.ipAddress + '/status';
+		const req = http.get(status_url, res => {
+			let data = '';
+			res.on('data', (chunk) => {
+				data += chunk;
+			});
+			res.on('end', () => {
+				var statusObject = JSON.parse(data);
+				that.power = statusObject.power;
+				this.update(statusObject)
+			});
+		}).on("error", (err) => {
+			console.log('Could not connect to ' + this.name);
+		});
+	}
 
 
 update(statusObject) {
@@ -78,16 +75,16 @@ update(statusObject) {
 }
 
 
-    getSensorState(callback) {
-        if (this.power >= this.threshold) {
-            callback(null, true);
-        } else {
-            callback(null, false);
-        }
-    }
+	getSensorState(callback) {
+		if (this.power >= this.threshold) {
+			callback(null, true);
+		} else {
+			callback(null, false);
+		}
+	}
 
-    
-    getServices() {
-        return this.enabledServices;
-    }
+	
+	getServices() {
+		return this.enabledServices;
+	}
 }


### PR DESCRIPTION
The `development` branch wasn't up to date with `main` which is why the changes seem to be quite comprehensive.

Following changes (compared to `main`) have been done:

 1) based on the Firmware Version of the Power Plug, the power value is parsed differently (since the structure of the `statusObject` changed in v2.0.0)
 2) `minimumTime` is now compared with the last *pulled* state change (instead of the last *persisted* state change)

Please review the changes carefully since I am uncertain if I understood the intention of the original implementation correctly.

Let me know if there are any questions!